### PR TITLE
Adiciona templates para issues e pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/relatar-bug.md
+++ b/.github/ISSUE_TEMPLATE/relatar-bug.md
@@ -1,0 +1,33 @@
+---
+name: Relatar Bug
+about: Relato de bug para ajudar a melhorar o sistema
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Descrição do bug**  
+<!-- Descreva de forma clara e concisa sobre o bug. -->
+
+**Para reproduzir**  
+<!-- Passos para reproduzir o bug:
+1. Vá para '...'
+2. Clique em '....'
+3. Arraste para '....'
+4. Veja o erro-->
+
+**Comportamento esperado**  
+<!-- Descreva de forma clara e concisa do comportamento esperado do sistema. -->
+
+**Screenshots**  
+<!-- Se aplicável, adicione imagens da tela para ajudar a explicar o seu problema. -->
+
+**Informações adicionais**  
+<!-- Comente outra informação relevante sobre o seu problema aqui. -->
+
+**Checklist**  
+- [ ] A issue possui nome significativo.
+- [ ] A issue possui descrição significativa.
+- [ ] A issue possui screenshots quando necessário.
+- [ ] A issue possui labels.

--- a/.github/ISSUE_TEMPLATE/requisitar-funcionalidade.md
+++ b/.github/ISSUE_TEMPLATE/requisitar-funcionalidade.md
@@ -1,0 +1,26 @@
+---
+name: Requisitar Funcionalidade
+about: Requisição de funcionalidade para o projeto
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Sua funcionalidade requisitada é relacionada com um problema? Descreva, por favor.**
+<!-- Descreva de forma clara e concisa qual é o problema. Ex. Eu fico frustrado quando [...] -->
+
+**Descreva a solução que você gostaria**
+<!-- Descreva de forma clara e concisa do que você quer que aconteça. -->
+
+**Descreva uma alternativa considerada**
+<!-- Descreva de forma clara e concisa qualquer solução alternativa ou alguma funcionalidade considerada. -->
+
+**Informações adicionais**
+<!-- Comente outra informação relevante sobre o sua funcionalidade requisitada aqui. -->
+
+**Checklist**  
+- [ ] A issue possui nome significativo.
+- [ ] A issue possui descrição significativa.
+- [ ] A issue possui screenshots quando necessárias.
+- [ ] A issue possui labels.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+**Descrição da mudança**  
+<!-- Descreva de forma clara e concisa sobre a mudança feita. -->
+
+**Tipo da mudança**  
+<!-- Marque o checkbox correspondente a mudança. -->
+- [ ] Correção de bug.
+- [ ] Adição de nova fucionalidade.
+
+**Issue relacionada**  
+<!-- Link com a isse -->
+
+**Screenshots**  
+<!-- Se aplicável, adicione imagens da tela para ajudar a explicar a mudança feita. -->
+
+**Informações adicionais**  
+<!-- Comente outra informação relevante sobre o seu problema aqui. -->
+
+**Checklist**  
+- [ ] O pull request possui nome significativo.
+- [ ] O pull request possui descrição significativa.
+- [ ] O pull request possui a marcação correspondente ao tipo da mudança.
+- [ ] O pull request possui screenshots quando necessário.
+- [ ] O pull request possui labels.


### PR DESCRIPTION
Copiei os templates para issue e pull requests do repositório do [Backend](https://github.com/fga-eps-mds/2019.2-Amika-Backend/tree/master/.github). 

Fixes https://github.com/fga-eps-mds/2019.2-Amika-Frontend/issues/1